### PR TITLE
added explicit override for the AMT port in case of SSH tunneling

### DIFF
--- a/amt/amt.go
+++ b/amt/amt.go
@@ -93,6 +93,9 @@ func Command(host Laststate, cmd string, options Optionset) (result Laststate) {
 		amtTLSskipCertCheck = true
 	}
 	result = host
+	if options.Port != 0 {
+		amtPort = strconv.Itoa(options.Port)
+	}
 
 	cmdPayload, _ := Asset(command.CommandOne)
 	uri := amtProto + "://" + host.Hostname + ":" + amtPort + "/wsman"

--- a/amt/types.go
+++ b/amt/types.go
@@ -31,6 +31,7 @@ type Optionset struct {
 	OptTimeout     int    `json:"opt_timeout" db:"opt_timeout"`
 	OptPassfile    string `json:"opt_passfile" db:"opt_passfile"`
 	OptCacertfile  string `json:"opt_cacertfile" db:"opt_cacertfile"`
+	Port           int    `json:"port"`
 	Username       string `json:"username"` // amtgo only
 	Password       string `json:"-"`        // amtgo only
 	CliDelay       int    `json:"-" db:"-"`


### PR DESCRIPTION
I've noticed that ports are hardcoded to 16992 and 16993 depending on the TLS being used or not. In my use case I tend to access a AMT machine via SSH tunnel so I'd like to override the expected port with an explicit value for it.

I didn't change command line settings since I believe this is not a useful thing for general-purpose usage of your CLI application/server, only for specific library usage like mine